### PR TITLE
feat: add an id hash to the jobs output, refactor io-models to own mo…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install-dev:
 dev: install-dev
 	docker run -it --rm -p 3003:3000 \
 		-v `pwd`:/builder -w /builder \
+		-e LOGGING_LEVEL=debug \
 		-e CARGO_HOME=/builder/.cargo_home \
 		virtualfinland/testbed-api-builder:devenv \
 		cargo watch -x 'run --features local-dev'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - RUST_BACKTRACE=1
       - LOGGING_LEVEL=debug
+      - CARGO_HOME=/builder/.cargo_home
     working_dir: /builder
     volumes:
       - ./:/builder

--- a/src/lib/api_app/src/api/requests.rs
+++ b/src/lib/api_app/src/api/requests.rs
@@ -29,12 +29,13 @@ pub async fn post_json_request<I: Debug + Serialize, O: Debug + Serialize + for<
     }
 }
 
-
+/// Requests many json post requests
+/// Returns tuples of good responses and headers along with request url
 pub async fn request_post_many_json_requests<I: Debug + Serialize, O: Debug + Serialize + for<'a> Deserialize<'a>>(
     endpoint_urls: Vec<&str>,
     request_input: &I,
     request_headers: HeaderMap,
-) -> Result<(StatusCode, Vec::<O>, String), APIRoutingError> {
+) -> Result<(StatusCode, Vec::<(O, HeaderMap, String)>, String), APIRoutingError> {
     // Get the job postings from the external services using concurrent requests and merge them
     // @see: https://stackoverflow.com/a/51047786
     let api_client = reqwest::Client::new();
@@ -53,12 +54,12 @@ pub async fn request_post_many_json_requests<I: Debug + Serialize, O: Debug + Se
     // If any response failed, all fail
     let mut response_status = StatusCode::OK;
     let mut error_response_body = String::new();
-    let mut good_responses = Vec::<O>::new();
+    let mut good_responses = Vec::<(O, HeaderMap, String)>::new();
     
     for r in response_json_bodies {
         match r {
             Ok(r) => {
-                good_responses.push(r.0);
+                good_responses.push((r.0, r.2, r.3));
             }
             Err(r) => {
                 response_status = r.get_status_code();
@@ -71,12 +72,14 @@ pub async fn request_post_many_json_requests<I: Debug + Serialize, O: Debug + Se
     Ok((response_status, good_responses, error_response_body))
 }
 
+/// Request a POST JSON request to an external service
+/// Returns the response body as a JSON object, status code, the response headers and request url 
 async fn request_post_json_request_data<I: Debug + Serialize, O: Debug + Serialize + for<'a> Deserialize<'a>>(
     client: &reqwest::Client,
     endpoint_url: &str,
     request_input: &I,
     request_headers: HeaderMap,
-) -> Result<(O, StatusCode), APIRoutingError> {
+) -> Result<(O, StatusCode, HeaderMap, String), APIRoutingError> {
     log::debug!("Url: {:#?}", endpoint_url);
     log::debug!("Input: {:#?}", request_input);
     log::debug!("Headers: {:#?}", request_headers);
@@ -89,6 +92,7 @@ async fn request_post_json_request_data<I: Debug + Serialize, O: Debug + Seriali
         .await?;
 
     let response_status = response.status();
+    let response_headers = response.headers().clone();
     log::debug!("Response status code: {:#?}", response_status);
 
     if response_status != 200 {
@@ -101,5 +105,5 @@ async fn request_post_json_request_data<I: Debug + Serialize, O: Debug + Seriali
         APIRoutingError::UnprocessableEntity("Error parsing response".to_string())
     })?;
 
-    Ok((response_output, response_status))
+    Ok((response_output, response_status, response_headers, endpoint_url.to_string()))
 }

--- a/src/lib/api_app/src/api/routes/testbed/productizers/figure/figure_models.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/figure/figure_models.rs
@@ -1,0 +1,23 @@
+use serde::{ Deserialize, Serialize };
+
+/**
+ * Population query parameters
+ */
+#[derive(Deserialize, Serialize, Debug)]
+pub struct PopulationQuery {
+    city: String,
+    year: String, // Note: front apps send strings, not numbers
+}
+
+/**
+ * Population response
+ */
+#[derive(Deserialize, Serialize, Debug)]
+pub struct PopulationResponse {
+    description: String,
+    #[serde(rename = "sourceName")]
+    source_name: String,
+    population: i128,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+}

--- a/src/lib/api_app/src/api/routes/testbed/productizers/figure/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/figure/mod.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::api:: {
     responses::{APIRoutingError, APIRoutingResponse},
     requests::post_json_request,
@@ -7,29 +5,11 @@ use crate::api:: {
 };
 use super::parse_testbed_request_headers;
 
-
-/**
- * Population query parameters
- */
-
-#[derive(Deserialize, Serialize, Debug)]
-struct PopulationQuery {
-    city: String,
-    year: String, // Note: front apps send strings, not numbers
-}
-
-/**
- * Population response
- */
-#[derive(Deserialize, Serialize, Debug)]
-struct PopulationResponse {
-    description: String,
-    #[serde(rename = "sourceName")]
-    source_name: String,
-    population: i128,
-    #[serde(rename = "updatedAt")]
-    updated_at: String,
-}
+mod figure_models;
+use figure_models::{
+    PopulationQuery,
+    PopulationResponse,
+};
 
 /**
  * Get population figure

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/job_models.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/job_models.rs
@@ -1,0 +1,78 @@
+use serde::{ Deserialize, Serialize };
+
+//
+// Inputs from the front app to the productizers
+// 
+#[derive(Deserialize, Serialize, Debug)]
+pub struct JobsRequest {
+    pub query: String,
+    pub location: RequestLocation,
+    pub paging: RequestPaging,
+}
+#[derive(Deserialize, Serialize, Debug)]
+pub struct RequestLocation {
+    pub countries: Vec<String>,
+    pub regions: Vec<String>,
+    pub municipalities: Vec<String>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+pub struct RequestPaging {
+    pub limit: usize,
+    pub offset: usize,
+}
+
+//
+// Outputs from the productizer APIs
+//
+#[derive(Deserialize, Serialize, Debug)]
+pub struct JobPostingResponse<T> {
+    pub results: Vec<T>,
+    #[serde(rename = "totalCount")]
+    pub total_count: i32,
+}
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct JobPosting {
+    pub employer: String,
+    pub location: Location,
+    #[serde(rename = "basicInfo")]
+    pub basic_info: BasicInfo,
+    #[serde(rename = "publishedAt")]
+    pub published_at: String,
+    #[serde(rename = "applicationEndDate")]
+    pub application_end_date: String,
+    #[serde(rename = "applicationUrl")]
+    pub application_url: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub struct Location {
+    pub municipality: String,
+    pub postcode: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub struct BasicInfo {
+    pub title: String,
+    pub description: String,
+    #[serde(rename = "workTimeType")]
+    pub work_time_type: String,
+}
+
+//
+// Transformed outputs for the frontend app
+// @TODO: there must be a better way to do this in rust
+//
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct JobPostingForFrontend {
+    pub id: String,
+    pub employer: String,
+    pub location: Location,
+    #[serde(rename = "basicInfo")]
+    pub basic_info: BasicInfo,
+    #[serde(rename = "publishedAt")]
+    pub published_at: String,
+    #[serde(rename = "applicationEndDate")]
+    pub application_end_date: String,
+    #[serde(rename = "applicationUrl")]
+    pub application_url: Option<String>,
+}

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/job_models.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/job_models.rs
@@ -65,6 +65,8 @@ pub struct BasicInfo {
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub struct JobPostingForFrontend {
     pub id: String,
+    #[serde(rename = "jobsSource")]
+    pub jobs_source: String,
     pub employer: String,
     pub location: Location,
     #[serde(rename = "basicInfo")]

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
@@ -8,7 +8,7 @@ use crate::api::{
 };
 use super::parse_testbed_request_headers;
 
-mod job_models;
+pub mod job_models;
 use job_models::{
     JobsRequest,
     JobPostingResponse,

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
@@ -37,7 +37,8 @@ pub async fn find_job_postings(
     let (response_status, good_responses, error_response_body) = request_post_many_json_requests::<JobsRequest, JobPostingResponse<JobPosting>>(
         endpoint_urls,
         &request_input,
-        request_headers
+        request_headers,
+        true
     ).await.expect("Something went wrong with the bulk requests");
 
     if response_status == StatusCode::OK {

--- a/src/lib/api_app/src/api/routes/testbed/productizers/user/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/user/mod.rs
@@ -12,7 +12,7 @@ pub async fn fetch_user_profile(
     request: ParsedRequest,
 ) -> Result<APIRoutingResponse, APIRoutingError> {
     let endpoint_url = "https://gateway.testbed.fi/test/lassipatanen/User/Profile?source=access_to_finland";
-    let request_input = json!({});
+    let request_input = json!({}); // Empty body
     let request_headers = parse_testbed_request_headers(request)?;
     let response = post_json_request::<JSONValue, JSONValue>(endpoint_url, &request_input, request_headers).await?;
     Ok(response)

--- a/src/lib/api_app/src/api/utils.rs
+++ b/src/lib/api_app/src/api/utils.rs
@@ -92,3 +92,9 @@ pub fn truncate_too_long_string(string: String, max_length: usize, postfix: &str
     }
     return string;
 }
+
+pub fn cut_string_by_delimiter_keep_right(string: String, delimiter: &str) -> String {
+    let split = string.split(delimiter);
+    let result = split.last().unwrap().to_string();
+    return result;
+}

--- a/src/lib/api_app/src/tests/mod.rs
+++ b/src/lib/api_app/src/tests/mod.rs
@@ -1,8 +1,12 @@
 #[cfg(test)]
 mod api_utils_test {
-    use crate::api::routes::testbed::productizers::job::{
-        job_models::{JobPostingResponse, JobPosting}, 
-        merge_job_posting_results
+    use crate::api::{
+        utils::cut_string_by_delimiter_keep_right,
+        routes::testbed::productizers::job::{
+            job_models::{JobPostingResponse, JobPosting}, 
+            merge_job_posting_results,
+            transform_job_posting_results
+        }
     };
 
     #[test]
@@ -14,8 +18,16 @@ mod api_utils_test {
         };
         assert_eq!(mock_response.results.len(), 4);
 
-        // Test merge
-        merge_job_posting_results(&mut mock_response.results);
-        assert_eq!(mock_response.results.len(), 3);
+        // Test mergeing
+        let mut transformed_results = transform_job_posting_results("tyomarkkinatori".to_string(), &mut mock_response.results);
+        merge_job_posting_results(&mut transformed_results);
+        assert_eq!(transformed_results.len(), 3);
     }
+
+    #[test]
+    fn string_util_tests() {
+        let test_string = "test string";
+        assert_eq!(cut_string_by_delimiter_keep_right(test_string.to_string(), " "), "string");
+    }
+    
 }

--- a/src/lib/api_app/src/tests/mod.rs
+++ b/src/lib/api_app/src/tests/mod.rs
@@ -1,13 +1,16 @@
 #[cfg(test)]
 mod api_utils_test {
-    use crate::api::routes::testbed::productizers::job::{JobPostingResponse, merge_job_posting_results};
+    use crate::api::routes::testbed::productizers::job::{
+        job_models::{JobPostingResponse, JobPosting}, 
+        merge_job_posting_results
+    };
 
     #[test]
     fn test_jobs_response_handlings() {
         let mut mock_response = {
             let input_path = "./src/tests/mock_data/job_postings_response.json";
             let text = std::fs::read_to_string(&input_path).unwrap();
-            serde_json::from_str::<JobPostingResponse>(&text).unwrap()
+            serde_json::from_str::<JobPostingResponse<JobPosting>>(&text).unwrap()
         };
         assert_eq!(mock_response.results.len(), 4);
 


### PR DESCRIPTION
- add `id` field to the jobs output: eg. 170493416056550875
- add `jobsSource` field to the output: eg. tyomarkkinatori
- the jobs request now allows failures, so if even one request succeeds there's a 200 OK response
- cleanups