### PR TITLE
build: lambda warmups by scheduling, rename the lambda functions with…

### DIFF
--- a/infra/main.py
+++ b/infra/main.py
@@ -7,14 +7,17 @@ import pulumi_aws as aws
 import pulumi_aws_native as aws_native
 from pulumi_command import local
 
+name = "testbed-api"
+stage = pulumi.get_stack()
+
 tags = {
-    "Name": "testbed-api",
-    "Environment": pulumi.get_stack(),
+    "Name": name,
+    "Environment": stage,
     "Project": "Virtual Finland",
 }
 
 testbed_api_lambda_role = aws_native.iam.Role(
-    "testbed_api_lambda_role",
+    f"{name}-lambda-role-{stage}",
     assume_role_policy_document=json.dumps(
         {
             "Version": "2012-10-17",
@@ -33,13 +36,13 @@ testbed_api_lambda_role = aws_native.iam.Role(
 )
 
 testbed_api_lambda_role_attachment = aws.iam.RolePolicyAttachment(
-    "testbed_api_lambda_role_attachment",
+    f"{name}-lambda-role-{stage}",
     role=pulumi.Output.concat(testbed_api_lambda_role.role_name),  # type: ignore
     policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
 )
 
 testbed_api_function = aws.lambda_.Function(
-    "testbed-api",
+    f"{name}-{stage}",
     runtime="provided.al2",  # amazonlinux2
     role=testbed_api_lambda_role.arn,
     handler="bootstrap",  # contents of the zip file
@@ -50,21 +53,50 @@ testbed_api_function = aws.lambda_.Function(
     tags=tags,
 )
 
-aws.lambda_.ProvisionedConcurrencyConfig(
-    "testbed-api-fixed-concurrency",
-    function_name=testbed_api_function.name,
-    qualifier=testbed_api_function.version,
-    provisioned_concurrent_executions=1,
+lambda_id_for_provisioning = pulumi.Output.concat(
+    "function:", testbed_api_function.name, ":", testbed_api_function.version
+)
+
+provision_autoscaling_target = aws.appautoscaling.Target(
+    f"{name}-provisioned-concurrency-target-{stage}",
+    resource_id=lambda_id_for_provisioning,
+    service_namespace="lambda",
+    scalable_dimension="lambda:function:ProvisionedConcurrency",
+    min_capacity=1,
+    max_capacity=10,
+)
+
+aws.appautoscaling.ScheduledAction(
+    f"{name}-provisioned-concurrency-by-day-{stage}",
+    service_namespace="lambda",
+    resource_id=provision_autoscaling_target.resource_id,
+    scalable_dimension="lambda:function:ProvisionedConcurrency",
+    schedule="0 6 * * ? *",
+    scalable_target_action=aws.appautoscaling.ScheduledActionScalableTargetActionArgs(
+        min_capacity=1,
+        max_capacity=10,
+    ),
+)
+aws.appautoscaling.ScheduledAction(
+    f"{name}-provisioned-concurrency-by-night-{stage}",
+    service_namespace="lambda",
+    resource_id=provision_autoscaling_target.resource_id,
+    scalable_dimension="lambda:function:ProvisionedConcurrency",
+    schedule="0 16 * * ? *",
+    scalable_target_action=aws.appautoscaling.ScheduledActionScalableTargetActionArgs(
+        min_capacity=0,
+        max_capacity=5,
+    ),
 )
 
 lambda_url = aws_native.lambda_.Url(
-    "testbed-api",
+    f"{name}-function-url-{stage}",
     target_function_arn=testbed_api_function.arn,
     auth_type=aws_native.lambda_.UrlAuthType.NONE,
 )
 
 add_permissions = local.Command(
-    "add_permissions",
+    f"{name}-add-permission-{stage}",
     create=pulumi.Output.concat(
         "aws lambda add-permission --function-name ",
         testbed_api_function.name,

--- a/infra/main.py
+++ b/infra/main.py
@@ -16,6 +16,9 @@ tags = {
     "Project": "Virtual Finland",
 }
 
+#
+# Lambda function
+#
 testbed_api_lambda_role = aws_native.iam.Role(
     f"{name}-lambda-role-{stage}",
     assume_role_policy_document=json.dumps(
@@ -53,6 +56,9 @@ testbed_api_function = aws.lambda_.Function(
     tags=tags,
 )
 
+#
+# Scheduled provisioned concurrency setup
+#
 lambda_id_for_provisioning = pulumi.Output.concat(
     "function:", testbed_api_function.name, ":", testbed_api_function.version
 )
@@ -89,6 +95,9 @@ aws.appautoscaling.ScheduledAction(
     ),
 )
 
+#
+# Function URL
+#
 lambda_url = aws_native.lambda_.Url(
     f"{name}-function-url-{stage}",
     target_function_arn=testbed_api_function.arn,


### PR DESCRIPTION
… stage names

- daily/nightly schedulers for the lambda concurrent provisioning, now with correct pulumi syntax and target
- rename lambda function resources with the stage-signature

note: recreates the function URL, so the dependants need an update to references