### PR TITLE
Fix/api path left slash

### DIFF
--- a/src/lib/api_app/src/api/mod.rs
+++ b/src/lib/api_app/src/api/mod.rs
@@ -20,7 +20,7 @@ pub async fn handler(
     let router_response = routes::exec_router_request(parsed_request).await;
     log::debug!("Response: {:#?},\nBody: {:#?},\nHeaders: {:#?}", 
         router_response.status_code, 
-        utils::truncate_too_long_string(router_response.body.to_string(), 5000, "..."), 
+        utils::strings::truncate_too_long_string(router_response.body.to_string(), 5000, "..."), 
         router_response.headers
     );
 

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
@@ -5,7 +5,7 @@ use math::round;
 use crate::api::{
     responses::{ APIRoutingError, APIRoutingResponse, resolve_external_service_bad_response },
     requests::request_post_many_json_requests,
-    utils::{ get_default_headers, ParsedRequest, cut_string_by_delimiter_keep_right },
+    utils::{ get_default_headers, ParsedRequest, strings::cut_string_by_delimiter_keep_right },
 };
 use super::parse_testbed_request_headers;
 

--- a/src/lib/api_app/src/api/utils.rs
+++ b/src/lib/api_app/src/api/utils.rs
@@ -88,23 +88,26 @@ pub fn get_plain_headers() -> HeaderMap {
 
 pub mod strings {
 
-    pub fn truncate_too_long_string(string: String, max_length: usize, postfix: &str) -> String {
-        if string.len() > max_length {
-            return string[..max_length].to_string() + postfix;
+    pub fn truncate_too_long_string(string: impl Into<String>, max_length: usize, postfix: &str) -> String {
+        let text = string.into();
+        if text.len() > max_length {
+            return text[..max_length].to_string() + postfix;
         }
-        return string;
+        return text;
     }
     
-    pub fn cut_string_by_delimiter_keep_right(string: String, delimiter: &str) -> String {
-        let split = string.split(delimiter);
+    pub fn cut_string_by_delimiter_keep_right(string: impl Into<String>, delimiter: &str) -> String {
+        let text = string.into();
+        let split = text.split(delimiter);
         let result = split.last().unwrap().to_string();
         return result;
     }
 
-    pub fn trim_left_slash(string: String) -> String {
-        if string.starts_with("/") {
-            return string[1..].to_string();
+    pub fn trim_left_slash(string: impl Into<String>) -> String {
+        let text = string.into();
+        if text.starts_with("/") {
+            return text[1..].to_string();
         }
-        return string;
+        return text;
     }
 }

--- a/src/lib/api_app/src/api/utils.rs
+++ b/src/lib/api_app/src/api/utils.rs
@@ -17,7 +17,7 @@ pub struct ParsedRequest {
  * Convert the lambda_http::Request to a parsed_request.
  */
 pub fn parse_router_request(request: Request) -> ParsedRequest {
-    let path = request.uri().path().clone().to_string();
+    let path = format!("/{}", strings::trim_left_slash(request.uri().path().clone().to_string()));
     let method = request.method().as_str().to_string();
     let query = request.query_string_parameters().clone();
     let headers = request.headers().clone();
@@ -86,15 +86,25 @@ pub fn get_plain_headers() -> HeaderMap {
     return headers;
 }
 
-pub fn truncate_too_long_string(string: String, max_length: usize, postfix: &str) -> String {
-    if string.len() > max_length {
-        return string[..max_length].to_string() + postfix;
-    }
-    return string;
-}
+pub mod strings {
 
-pub fn cut_string_by_delimiter_keep_right(string: String, delimiter: &str) -> String {
-    let split = string.split(delimiter);
-    let result = split.last().unwrap().to_string();
-    return result;
+    pub fn truncate_too_long_string(string: String, max_length: usize, postfix: &str) -> String {
+        if string.len() > max_length {
+            return string[..max_length].to_string() + postfix;
+        }
+        return string;
+    }
+    
+    pub fn cut_string_by_delimiter_keep_right(string: String, delimiter: &str) -> String {
+        let split = string.split(delimiter);
+        let result = split.last().unwrap().to_string();
+        return result;
+    }
+
+    pub fn trim_left_slash(string: String) -> String {
+        if string.starts_with("/") {
+            return string[1..].to_string();
+        }
+        return string;
+    }
 }

--- a/src/lib/api_app/src/api/utils.rs
+++ b/src/lib/api_app/src/api/utils.rs
@@ -17,7 +17,7 @@ pub struct ParsedRequest {
  * Convert the lambda_http::Request to a parsed_request.
  */
 pub fn parse_router_request(request: Request) -> ParsedRequest {
-    let path = format!("/{}", strings::trim_left_slash(request.uri().path().clone().to_string()));
+    let path = format!("/{}", strings::trim_left_slashes(request.uri().path().clone().to_string()));
     let method = request.method().as_str().to_string();
     let query = request.query_string_parameters().clone();
     let headers = request.headers().clone();
@@ -103,11 +103,12 @@ pub mod strings {
         return result;
     }
 
-    pub fn trim_left_slash(string: impl Into<String>) -> String {
+    pub fn trim_left_slashes(string: impl Into<String>) -> String {
         let text = string.into();
-        if text.starts_with("/") {
-            return text[1..].to_string();
+        let mut result = text.clone();
+        while result.starts_with("/") {
+            result = result[1..].to_string();
         }
-        return text;
+        return result;
     }
 }

--- a/src/lib/api_app/src/tests/mod.rs
+++ b/src/lib/api_app/src/tests/mod.rs
@@ -4,7 +4,7 @@ mod api_utils_test {
     use http::{ HeaderValue, header::{ HeaderMap, HeaderName } };
     use lambda_http::aws_lambda_events::query_map::QueryMap;
     use crate::api::{
-        utils::{ strings::{cut_string_by_delimiter_keep_right, trim_left_slash}, ParsedRequest },
+        utils::{ strings::{cut_string_by_delimiter_keep_right, trim_left_slashes}, ParsedRequest },
         routes::testbed::productizers::job::{
             job_models::{ JobPostingResponse, JobPosting },
             merge_job_posting_results,
@@ -76,6 +76,6 @@ mod api_utils_test {
         let test_string = "test string";
         assert_eq!(cut_string_by_delimiter_keep_right(test_string, " "), "string");
 
-        assert_eq!(trim_left_slash("//test"), "/test");
+        assert_eq!(trim_left_slashes("//test/test"), "test/test");
     }
 }

--- a/src/lib/api_app/src/tests/mod.rs
+++ b/src/lib/api_app/src/tests/mod.rs
@@ -4,7 +4,7 @@ mod api_utils_test {
     use http::{ HeaderValue, header::{ HeaderMap, HeaderName } };
     use lambda_http::aws_lambda_events::query_map::QueryMap;
     use crate::api::{
-        utils::{ cut_string_by_delimiter_keep_right, ParsedRequest },
+        utils::{ strings::cut_string_by_delimiter_keep_right, ParsedRequest },
         routes::testbed::productizers::job::{
             job_models::{ JobPostingResponse, JobPosting },
             merge_job_posting_results,

--- a/src/lib/api_app/src/tests/mod.rs
+++ b/src/lib/api_app/src/tests/mod.rs
@@ -4,7 +4,7 @@ mod api_utils_test {
     use http::{ HeaderValue, header::{ HeaderMap, HeaderName } };
     use lambda_http::aws_lambda_events::query_map::QueryMap;
     use crate::api::{
-        utils::{ strings::cut_string_by_delimiter_keep_right, ParsedRequest },
+        utils::{ strings::{cut_string_by_delimiter_keep_right, trim_left_slash}, ParsedRequest },
         routes::testbed::productizers::job::{
             job_models::{ JobPostingResponse, JobPosting },
             merge_job_posting_results,
@@ -74,6 +74,8 @@ mod api_utils_test {
     #[test]
     fn string_util_tests() {
         let test_string = "test string";
-        assert_eq!(cut_string_by_delimiter_keep_right(test_string.to_string(), " "), "string");
+        assert_eq!(cut_string_by_delimiter_keep_right(test_string, " "), "string");
+
+        assert_eq!(trim_left_slash("//test"), "/test");
     }
 }


### PR DESCRIPTION
- accepts paths with double slash roots: `<host>//<path>` for ensured functionality