### PR TITLE
refactor: move productizer endpoint urls to environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+USERS_PRODUCTIZER_ENDPOINT = "https://gateway.testbed.fi/test/lassipatanen/User/Profile?source=access_to_finland"
+POPULATION_FIGURE_PRODUCTIZER_ENDPOINT = "https://gateway.testbed.fi/test/lsipii/Figure/Population?source=virtual_finland"
+JOB_POSTING_PRODUCTIZER_ENDPOINTS = "https://gateway.testbed.fi/test/lassipatanen/Job/JobPosting?source=tyomarkkinatori, https://gateway.testbed.fi/test/lassipatanen/Job/JobPosting?source=jobs_in_finland"

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,1 @@
+USERS_PRODUCTIZER_ENDPOINT = "https://gateway.testbed.fi/test/lassipatanen/User/Profile?source=access_to_finland__staging"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 hot-lib-reloader = { version = "^0.6", optional = true }
 tokio = { version = "^1.21.2", features = ["full"] }
+dotenv = "^0.15.0"
 api_app = { path = "./src/lib/api_app" }
 http_server = { path = "./src/lib/http_server" }
 lambda_service = { path = "./src/lib/lambda_service" }

--- a/infra/main.py
+++ b/infra/main.py
@@ -7,6 +7,8 @@ import pulumi_aws as aws
 import pulumi_aws_native as aws_native
 from pulumi_command import local
 
+from infra.utils import get_env_var
+
 name = "testbed-api"
 stage = pulumi.get_stack()
 
@@ -56,7 +58,16 @@ testbed_api_function = aws.lambda_.Function(
     tags=tags,
     environment=aws.lambda_.FunctionEnvironmentArgs(
         variables={
-            "STAGE": stage,
+            "LOGGING_LEVEL": "info",
+            "USERS_PRODUCTIZER_ENDPOINT": get_env_var(
+                "USERS_PRODUCTIZER_ENDPOINT", stage
+            ),
+            "POPULATION_FIGURE_PRODUCTIZER_ENDPOINT": get_env_var(
+                "POPULATION_FIGURE_PRODUCTIZER_ENDPOINT", stage
+            ),
+            "JOB_POSTING_PRODUCTIZER_ENDPOINTS": get_env_var(
+                "JOB_POSTING_PRODUCTIZER_ENDPOINTS", stage
+            ),
         }
     ),
 )

--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -2,3 +2,4 @@ pulumi==3.40.0
 pulumi-aws==5.18.0
 pulumi-aws-native==0.29.0
 pulumi-command==0.5.2
+python-dotenv==0.21.0

--- a/infra/utils.py
+++ b/infra/utils.py
@@ -1,0 +1,20 @@
+import os
+from typing import Dict, Union
+
+
+def get_config(stage: str) -> Dict[str, Union[str, None]]:
+    from dotenv import dotenv_values  # type: ignore
+
+    return {
+        **dotenv_values(f"../.env"),
+        **dotenv_values(f"../.env.{stage}"),
+        **os.environ,  # override loaded values with environment variables
+    }
+
+
+def get_env_var(name: str, stage: str) -> str:
+    config = get_config(stage)
+
+    if name not in config or config[name] is None:
+        raise KeyError(f"Missing environment variable {name}")
+    return config[name]  # type: ignore

--- a/src/lib/api_app/src/api/routes/testbed/productizers/figure/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/figure/mod.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use crate::api::{
     responses::{ APIRoutingError, APIRoutingResponse },
     requests::post_json_request,
@@ -12,8 +14,9 @@ use figure_models::{ PopulationQuery, PopulationResponse };
  * Get population figure
  */
 pub async fn get_population(request: ParsedRequest) -> Result<APIRoutingResponse, APIRoutingError> {
-    let endpoint_url =
-        "https://gateway.testbed.fi/test/lsipii/Figure/Population?source=virtual_finland";
+    let endpoint_url = env
+        ::var("POPULATION_FIGURE_PRODUCTIZER_ENDPOINT")
+        .expect("POPULATION_FIGURE_PRODUCTIZER_ENDPOINT must be set");
     let request_input: PopulationQuery = serde_json::from_str(request.body.as_str())?;
     let request_headers = parse_testbed_request_headers(request)?;
     let response = post_json_request::<PopulationQuery, PopulationResponse>(

--- a/src/lib/api_app/src/api/routes/testbed/productizers/user/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/user/mod.rs
@@ -12,18 +12,9 @@ use super::parse_testbed_request_headers;
 pub async fn fetch_user_profile(
     request: ParsedRequest
 ) -> Result<APIRoutingResponse, APIRoutingError> {
-    // @TODO: this is a hotfix for the testbed staged source param resolution
-    let path_env = env::var("STAGE").expect("STAGE must be set");
-    let endpoint_url = match path_env.as_str() {
-        "local" =>
-            "https://gateway.testbed.fi/test/lassipatanen/User/Profile?source=access_to_finland",
-        "dev" =>
-            "https://gateway.testbed.fi/test/lassipatanen/User/Profile?source=access_to_finland",
-        "staging" =>
-            "https://gateway.testbed.fi/test/lassipatanen/User/Profile?source=access_to_finland__staging",
-        _ => panic!("Unknown STAGE value"),
-    };
-
+    let endpoint_url = env
+        ::var("USERS_PRODUCTIZER_ENDPOINT")
+        .expect("USERS_PRODUCTIZER_ENDPOINT must be set");
     let request_input = json!({}); // Empty body
     let request_headers = parse_testbed_request_headers(request)?;
     let response = post_json_request::<JSONValue, JSONValue>(

--- a/src/lib/api_app/src/api/utils.rs
+++ b/src/lib/api_app/src/api/utils.rs
@@ -1,9 +1,6 @@
 use lambda_http::aws_lambda_events::query_map::QueryMap;
-use http::{
-    HeaderValue,
-    header::{HeaderMap, HeaderName}
-};
-use lambda_http::{Body, Request, RequestExt};
+use http::{ HeaderValue, header::{ HeaderMap, HeaderName } };
+use lambda_http::{ Body, Request, RequestExt };
 
 pub struct ParsedRequest {
     pub path: String,
@@ -46,19 +43,19 @@ pub fn get_cors_response_headers() -> HeaderMap {
 
     headers.insert(
         HeaderName::from_static("access-control-allow-origin"),
-        HeaderValue::from_static("*"),
+        HeaderValue::from_static("*")
     );
 
     headers.insert(
         HeaderName::from_static("access-control-allow-methods"),
-        HeaderValue::from_static("GET, POST, OPTIONS"),
+        HeaderValue::from_static("GET, POST, OPTIONS")
     );
 
     headers.insert(
         HeaderName::from_static("access-control-allow-headers"),
         HeaderValue::from_static(
-            "content-type, authorization, x-authorization-provider, x-authorization-context",
-        ),
+            "content-type, authorization, x-authorization-provider, x-authorization-context"
+        )
     );
 
     return headers;
@@ -69,7 +66,7 @@ pub fn get_default_headers() -> HeaderMap {
 
     cors_headers.insert(
         HeaderName::from_static("content-type"),
-        HeaderValue::from_static("application/json"),
+        HeaderValue::from_static("application/json")
     );
 
     return cors_headers;
@@ -78,25 +75,28 @@ pub fn get_default_headers() -> HeaderMap {
 pub fn get_plain_headers() -> HeaderMap {
     let mut headers = HeaderMap::new();
 
-    headers.insert(
-        HeaderName::from_static("content-type"),
-        HeaderValue::from_static("text/plain"),
-    );
+    headers.insert(HeaderName::from_static("content-type"), HeaderValue::from_static("text/plain"));
 
     return headers;
 }
 
 pub mod strings {
-
-    pub fn truncate_too_long_string(string: impl Into<String>, max_length: usize, postfix: &str) -> String {
+    pub fn truncate_too_long_string(
+        string: impl Into<String>,
+        max_length: usize,
+        postfix: &str
+    ) -> String {
         let text = string.into();
         if text.len() > max_length {
             return text[..max_length].to_string() + postfix;
         }
         return text;
     }
-    
-    pub fn cut_string_by_delimiter_keep_right(string: impl Into<String>, delimiter: &str) -> String {
+
+    pub fn cut_string_by_delimiter_keep_right(
+        string: impl Into<String>,
+        delimiter: &str
+    ) -> String {
         let text = string.into();
         let split = text.split(delimiter);
         let result = split.last().unwrap().to_string();
@@ -109,6 +109,13 @@ pub mod strings {
         while result.starts_with("/") {
             result = result[1..].to_string();
         }
+        return result;
+    }
+
+    pub fn parse_comma_separated_list(string: impl Into<String>) -> Vec<String> {
+        let text = string.into();
+        let split = text.split(",");
+        let result: Vec<String> = split.map(|s| s.trim().to_string()).collect();
         return result;
     }
 }

--- a/src/lib/api_app/src/tests/mod.rs
+++ b/src/lib/api_app/src/tests/mod.rs
@@ -4,7 +4,14 @@ mod api_utils_test {
     use http::{ HeaderValue, header::{ HeaderMap, HeaderName } };
     use lambda_http::aws_lambda_events::query_map::QueryMap;
     use crate::api::{
-        utils::{ strings::{cut_string_by_delimiter_keep_right, trim_left_slashes}, ParsedRequest },
+        utils::{
+            strings::{
+                cut_string_by_delimiter_keep_right,
+                trim_left_slashes,
+                parse_comma_separated_list,
+            },
+            ParsedRequest,
+        },
         routes::testbed::productizers::job::{
             job_models::{ JobPostingResponse, JobPosting },
             merge_job_posting_results,
@@ -33,7 +40,7 @@ mod api_utils_test {
 
     #[test]
     fn test_request_parsing() {
-        let endpoint_urls = vec!["http1", "http2"];
+        let endpoint_urls = vec![String::from("http1"), String::from("http2")];
 
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -77,5 +84,10 @@ mod api_utils_test {
         assert_eq!(cut_string_by_delimiter_keep_right(test_string, " "), "string");
 
         assert_eq!(trim_left_slashes("//test/test"), "test/test");
+
+        assert_eq!(
+            parse_comma_separated_list("test1,test2, test3"),
+            vec!["test1", "test2", "test3"]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,11 @@ mod hot_lib {
 #[tokio::main]
 async fn main() {
     #[cfg(feature = "local-dev")]
-    dotenv::from_filename(".env").ok();
+    {
+        let stage = std::env::var("STAGE").unwrap_or_else(|_| "local".to_string());
+        dotenv::from_filename(format!(".env.{}", stage)).ok(); // override with stage specific env if any
+        dotenv::from_filename(".env").ok();
+    }
 
     // Initialize the logger
     let logging_level: LevelFilter = match std::env::var("LOGGING_LEVEL") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use api_app::log::LevelFilter;
 use api_app::simple_logger::SimpleLogger;
 mod tests;
-
+#[cfg(feature = "local-dev")]
+use dotenv;
 #[cfg(feature = "local-dev")]
 use http_server as service;
 #[cfg(not(feature = "local-dev"))]
@@ -27,16 +28,16 @@ mod hot_lib {
 
 #[tokio::main]
 async fn main() {
+    #[cfg(feature = "local-dev")]
+    dotenv::from_filename(".env").ok();
+
     // Initialize the logger
     let logging_level: LevelFilter = match std::env::var("LOGGING_LEVEL") {
         Ok(level) => LevelFilter::from_str(level.as_ref()).expect("Invalid logging level"),
         Err(_) => LevelFilter::Info,
     };
 
-    SimpleLogger::new()
-        .with_level(logging_level)
-        .init()
-        .unwrap();
+    SimpleLogger::new().with_level(logging_level).init().unwrap();
 
     #[allow(clippy::never_loop)] // Allow the loop to be skipped in a not-local dev
     loop {


### PR DESCRIPTION
- read productizer urls from environment variables
- for local dev, read defaults with dotenv
- stage specific overrides like `.env.{stage}`, eg. `.env.local`