### PR TITLE
feat: add a wake signal handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Cargo.lock
 infra/build/*
 !infra/build/.gitkeep
 .cargo_home
+
+.env.local

--- a/src/lib/api_app/src/api/routes/application.rs
+++ b/src/lib/api_app/src/api/routes/application.rs
@@ -1,44 +1,52 @@
-use http::{HeaderMap, StatusCode, HeaderValue};
+use http::{ HeaderMap, StatusCode, HeaderValue };
 use reqwest::Response;
-use serde_json::json;
-use std::fs;
+use serde_json::{ json, Value as JsonValue };
+use std::{ fs, env };
 
 use crate::api::{
-    responses::{APIRoutingError, APIRoutingResponse},
-    utils::{ParsedRequest, get_cors_response_headers, get_default_headers, get_plain_headers},
-    responses::resolve_external_service_bad_response,
+    responses::{ APIRoutingError, APIRoutingResponse, resolve_external_service_bad_response },
+    requests::request_post_many_json_requests,
+    utils::{ ParsedRequest, get_cors_response_headers, get_default_headers, get_plain_headers },
 };
 
 pub async fn cors_preflight_response(
-    _request: ParsedRequest,
+    _request: ParsedRequest
 ) -> Result<APIRoutingResponse, APIRoutingError> {
     Ok(APIRoutingResponse::new(StatusCode::OK, "", get_cors_response_headers()))
 }
 
 pub async fn index(_request: ParsedRequest) -> Result<APIRoutingResponse, APIRoutingError> {
-    Ok(APIRoutingResponse::new(StatusCode::TEMPORARY_REDIRECT, "Redirecting to /docs", {
-        let mut headers = HeaderMap::new();
-        headers.insert("Location", HeaderValue::from_static("/docs"));
-        headers
-    }))
+    Ok(
+        APIRoutingResponse::new(StatusCode::TEMPORARY_REDIRECT, "Redirecting to /docs", {
+            let mut headers = HeaderMap::new();
+            headers.insert("Location", HeaderValue::from_static("/docs"));
+            headers
+        })
+    )
 }
 
 pub async fn docs(_request: ParsedRequest) -> Result<APIRoutingResponse, APIRoutingError> {
     let body = fs::read_to_string("./openapi/index.html").expect("Unable to read index.html file");
-    Ok(APIRoutingResponse::new(StatusCode::OK, body.as_ref(), {
-        let mut headers = HeaderMap::new();
-        headers.insert("Content-Type", HeaderValue::from_static("text/html"));
-        headers
-    }))
+    Ok(
+        APIRoutingResponse::new(StatusCode::OK, body.as_ref(), {
+            let mut headers = HeaderMap::new();
+            headers.insert("Content-Type", HeaderValue::from_static("text/html"));
+            headers
+        })
+    )
 }
 
 pub async fn openapi_spec(_request: ParsedRequest) -> Result<APIRoutingResponse, APIRoutingError> {
-    let body = fs::read_to_string("./openapi/openapi.yml").expect("Unable to read openapi.yml file");
-    Ok(APIRoutingResponse::new(StatusCode::OK, body.as_ref(), {
-        let mut headers = HeaderMap::new();
-        headers.insert("Content-Type", HeaderValue::from_static("application/octet-stream"));
-        headers
-    }))
+    let body = fs
+        ::read_to_string("./openapi/openapi.yml")
+        .expect("Unable to read openapi.yml file");
+    Ok(
+        APIRoutingResponse::new(StatusCode::OK, body.as_ref(), {
+            let mut headers = HeaderMap::new();
+            headers.insert("Content-Type", HeaderValue::from_static("application/octet-stream"));
+            headers
+        })
+    )
 }
 
 pub async fn health_check(_request: ParsedRequest) -> Result<APIRoutingResponse, APIRoutingError> {
@@ -50,16 +58,42 @@ pub async fn not_found(_request: ParsedRequest) -> Result<APIRoutingResponse, AP
         status_code: StatusCode::NOT_FOUND,
         body: json!({
             "message": "Not Found".to_string(),
-        })
-        .to_string(),
+        }).to_string(),
         headers: get_default_headers(),
     })
 }
 
 pub async fn get_external_service_bad_response(
-    response: Response,
+    response: Response
 ) -> Result<APIRoutingResponse, APIRoutingError> {
     let status_code = response.status();
     let response_body = response.text().await?;
     return resolve_external_service_bad_response(status_code, response_body);
+}
+
+pub async fn wake_up_external_services(
+    _request: ParsedRequest
+) -> Result<APIRoutingResponse, APIRoutingError> {
+    let endpoints = vec![
+        format!("{}/health", env::var("AUTHENTICATION_GW_LAMBDA_ENDPOINT").unwrap_or_default()),
+        format!("{}/wake-up", env::var("USERS_API_LAMBDA_ENDPOINT").unwrap_or_default()),
+        format!("{}/wake-up", env::var("TMT_PRODUCTIZER_LAMBDA_ENDPOINT").unwrap_or_default()),
+        format!(
+            "{}/wake-up",
+            env::var("JOBS_IN_FINLAND_PRODUCTIZER_LAMBDA_ENDPOINT").unwrap_or_default()
+        )
+    ];
+
+    let wake_up_input = json!({
+       "message": "Wake up!".to_string(),
+    });
+
+    request_post_many_json_requests::<JsonValue, JsonValue>(
+        endpoints,
+        &wake_up_input,
+        get_default_headers(),
+        true
+    ).await?;
+
+    Ok(APIRoutingResponse::new(StatusCode::OK, "OK", get_plain_headers()))
 }

--- a/src/lib/api_app/src/api/routes/mod.rs
+++ b/src/lib/api_app/src/api/routes/mod.rs
@@ -1,7 +1,4 @@
-use super::{
-    responses::{APIRoutingResponse, APIRoutingError},
-    utils::ParsedRequest,
-};
+use super::{ responses::{ APIRoutingResponse, APIRoutingError }, utils::ParsedRequest };
 
 pub mod application;
 pub mod testbed;
@@ -11,7 +8,9 @@ pub mod testbed;
  */
 pub async fn exec_router_request(parsed_request: ParsedRequest) -> APIRoutingResponse {
     match get_router_response(parsed_request).await {
-        Ok(response) => return response,
+        Ok(response) => {
+            return response;
+        }
         Err(e) => {
             return APIRoutingResponse::from_routing_error(e);
         }
@@ -22,24 +21,15 @@ pub async fn exec_router_request(parsed_request: ParsedRequest) -> APIRoutingRes
  * API router
  */
 pub async fn get_router_response(
-    parsed_request: ParsedRequest,
+    parsed_request: ParsedRequest
 ) -> Result<APIRoutingResponse, APIRoutingError> {
-   match (parsed_request.method.as_str(), parsed_request.path.as_str()) {
-        ("OPTIONS", _) => {
-            application::cors_preflight_response(parsed_request).await
-        }
-        ("GET", "/") => {
-            application::index(parsed_request).await
-        }
-        ("GET", "/docs") => {
-            application::docs(parsed_request).await
-        }
-        ("GET", "/openapi.yml") => {
-            application::openapi_spec(parsed_request).await
-        }
-        ("GET", "/health") => {
-            application::health_check(parsed_request).await
-        }
+    match (parsed_request.method.as_str(), parsed_request.path.as_str()) {
+        ("OPTIONS", _) => { application::cors_preflight_response(parsed_request).await }
+        ("GET", "/") => { application::index(parsed_request).await }
+        ("GET", "/docs") => { application::docs(parsed_request).await }
+        ("GET", "/openapi.yml") => { application::openapi_spec(parsed_request).await }
+        ("GET", "/health") => { application::health_check(parsed_request).await }
+        ("GET", "/wake-up") => { application::wake_up_external_services(parsed_request).await }
         ("POST", "/testbed/reverse-proxy") => {
             testbed::engage_reverse_proxy_request(parsed_request).await
         }
@@ -52,8 +42,6 @@ pub async fn get_router_response(
         ("POST", "/testbed/productizers/user-profile") => {
             testbed::productizers::user::fetch_user_profile(parsed_request).await
         }
-        _ => {
-            application::not_found(parsed_request).await
-        }
+        _ => { application::not_found(parsed_request).await }
     }
 }


### PR DESCRIPTION
- drop the provisioned concurrency scheduler
- add a `/wake-up` route that sends the dependent external lambda-api-services with a wake-signal