### PR TITLE
Extend occupation isco-codes to esco

### DIFF
--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/job_input_extenders.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/job_input_extenders.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use itertools::Itertools;
 use serde::Deserialize;
 use serde_json::{ from_str as deserialize_json_from_string };
@@ -55,10 +54,7 @@ fn extend_job_occupation_uris(occupation_uri: String, codesets: &Vec<Occupation>
 }
 
 fn get_esco_occupations_codeset() -> Vec<Occupation> {
-    let file_path = "./src/lib/api_app/src/api/resources/testbed/jobs/esco-1.1.0-occupations.json";
-    let contents = fs
-        ::read_to_string(file_path)
-        .expect("Unable to retrieve the ESCO occupations codeset");
+    let contents = include_str!("../../../../resources/testbed/jobs/esco-1.1.0-occupations.json");
     return deserialize_json_from_string::<Vec<Occupation>>(contents.as_ref()).expect(
         "Failed to parse the ESCO occupations codeset"
     );

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/job_input_extenders.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/job_input_extenders.rs
@@ -1,0 +1,65 @@
+use std::fs;
+use itertools::Itertools;
+use serde::Deserialize;
+use serde_json::{ from_str as deserialize_json_from_string };
+
+//
+// Inputs from the frontend
+//
+#[derive(Deserialize)]
+struct Occupation {
+    pub uri: Option<String>,
+    pub broader: Option<Vec<String>>,
+}
+
+pub fn extend_job_occupations(occupations: Vec<String>) -> Vec<String> {
+    let mut extended_occupations: Vec<String> = Vec::new();
+    let codesets = get_esco_occupations_codeset();
+
+    for occupation_uri in occupations {
+        if !occupation_uri.contains("://data.europa.eu/esco/occupation/") {
+            let mut extended_occupation_uris = extend_job_occupation_uris(
+                occupation_uri,
+                &codesets
+            );
+            extended_occupations.append(&mut extended_occupation_uris);
+        } else {
+            extended_occupations.push(occupation_uri);
+        }
+    }
+    extended_occupations.into_iter().unique().collect()
+}
+
+fn extend_job_occupation_uris(occupation_uri: String, codesets: &Vec<Occupation>) -> Vec<String> {
+    let mut extended_occupation_uris: Vec<String> = Vec::new();
+
+    for codeset in codesets {
+        if !codeset.uri.is_some() || !codeset.broader.is_some() {
+            continue;
+        }
+
+        let uri = codeset.uri
+            .clone()
+            .expect("Failed to retrieve the URI of the ESCO occupation codeset");
+        let broader = codeset.broader
+            .clone()
+            .expect("Failed to retrieve the broader of the ESCO occupation codeset");
+
+        if broader.contains(&occupation_uri) {
+            extended_occupation_uris.push(uri.clone());
+            let mut sub_occupation_uris = extend_job_occupation_uris(uri, codesets);
+            extended_occupation_uris.append(&mut sub_occupation_uris);
+        }
+    }
+    extended_occupation_uris
+}
+
+fn get_esco_occupations_codeset() -> Vec<Occupation> {
+    let file_path = "./src/lib/api_app/src/api/resources/testbed/jobs/esco-1.1.0-occupations.json";
+    let contents = fs
+        ::read_to_string(file_path)
+        .expect("Unable to retrieve the ESCO occupations codeset");
+    return deserialize_json_from_string::<Vec<Occupation>>(contents.as_ref()).expect(
+        "Failed to parse the ESCO occupations codeset"
+    );
+}

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/job_models.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/job_models.rs
@@ -8,7 +8,7 @@ use serde::{ Deserialize, Serialize };
 pub struct JobsRequestFromFrontend {
     pub query: String,
     pub location: RequestLocation,
-    pub requirements: Option<RequestRequirements>,
+    pub requirements: RequestRequirements,
     pub paging: RequestPagingFromFrontend,
 }
 
@@ -35,7 +35,7 @@ pub struct ProductizerRequest {
 pub struct JobsRequest {
     pub query: String,
     pub location: RequestLocation,
-    pub requirements: Option<RequestRequirements>,
+    pub requirements: RequestRequirements,
     pub paging: RequestPaging,
 }
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
@@ -98,7 +98,7 @@ pub fn construct_productizer_requests(
     endpoint_urls: Vec<String>
 ) -> Result<ProductizerRequest, APIRoutingError> {
     let original_input = serde_json::from_str::<JobsRequestFromFrontend>(request.body.as_str())?;
-    let request_input = parse_job_request_input(original_input.clone());
+    let request_input = parse_job_request_input(&original_input);
 
     let request_headers = parse_testbed_request_headers(request)?;
 
@@ -132,17 +132,17 @@ pub fn construct_productizer_requests(
     });
 }
 
-pub fn parse_job_request_input(request_input: JobsRequestFromFrontend) -> JobsRequestFromFrontend {
-    let mut request_input = request_input;
+pub fn parse_job_request_input(request_input: &JobsRequestFromFrontend) -> JobsRequestFromFrontend {
+    let mut frontend_input = request_input.clone();
 
     // Parse the requirements
-    if request_input.requirements.occupations.is_some() {
-        let occupations = request_input.requirements.occupations.unwrap();
+    if frontend_input.requirements.occupations.is_some() {
+        let occupations = frontend_input.requirements.occupations.unwrap();
         let extended_occupations = extend_job_occupations(occupations);
-        request_input.requirements.occupations = Some(extended_occupations);
+        frontend_input.requirements.occupations = Some(extended_occupations);
     }
 
-    request_input
+    frontend_input
 }
 
 /**

--- a/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
+++ b/src/lib/api_app/src/api/routes/testbed/productizers/job/mod.rs
@@ -24,6 +24,9 @@ use job_models::{
     ProductizerRequest,
 };
 
+mod job_input_extenders;
+use job_input_extenders::extend_job_occupations;
+
 /**
  * Get job postings
  */
@@ -94,8 +97,8 @@ pub fn construct_productizer_requests(
     request: ParsedRequest,
     endpoint_urls: Vec<String>
 ) -> Result<ProductizerRequest, APIRoutingError> {
-    let request_input = serde_json::from_str::<JobsRequestFromFrontend>(request.body.as_str())?;
-    let originial_input = request_input.clone();
+    let original_input = serde_json::from_str::<JobsRequestFromFrontend>(request.body.as_str())?;
+    let request_input = parse_job_request_input(original_input.clone());
 
     let request_headers = parse_testbed_request_headers(request)?;
 
@@ -125,8 +128,21 @@ pub fn construct_productizer_requests(
         endpoint_urls: endpoint_urls,
         request_input: jobs_request,
         headers: request_headers,
-        original_input: originial_input,
+        original_input: original_input,
     });
+}
+
+pub fn parse_job_request_input(request_input: JobsRequestFromFrontend) -> JobsRequestFromFrontend {
+    let mut request_input = request_input;
+
+    // Parse the requirements
+    if request_input.requirements.occupations.is_some() {
+        let occupations = request_input.requirements.occupations.unwrap();
+        let extended_occupations = extend_job_occupations(occupations);
+        request_input.requirements.occupations = Some(extended_occupations);
+    }
+
+    request_input
 }
 
 /**


### PR DESCRIPTION
Move the isco-esco expander from tmt-productizer to testbed-api