### PR TITLE
Testbed consent API and local development tools upgrade

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,5 @@
 USERS_PRODUCTIZER_ENDPOINT=http://host.docker.internal:5001/productizer/test/lassipatanen/User/Profile/
-USERS_API_LAMBDA_ENDPOINT=http://host.docker.internal:5001/
+USERS_API_ENDPOINT_ORIGIN=http://host.docker.internal:5001
+AUTHENTICATION_GW_ENDPOINT_ORIGIN=https://virtualfinland-authgw.localhost
+TMT_PRODUCTIZER_ENDPOINT_ORIGIN=http://host.docker.internal:5286
+JOBS_IN_FINLAND_PRODUCTIZER_ENDPOINT_ORIGIN=http://host.docker.internal:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,5 @@ services:
       - ./:/builder
     ports:
       - 3003:3003
-    stdin_open: true
-    tty: true
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/infra/main.py
+++ b/infra/main.py
@@ -83,10 +83,10 @@ testbed_api_function = aws.lambda_.Function(
         variables={
             "LOGGING_LEVEL": "info",
             **utils.get_dotenv_configuration(stage),  # type: ignore
-            "AUTHENTICATION_GW_LAMBDA_ENDPOINT": authenticationGWLambdaEndpoint,
-            "USERS_API_LAMBDA_ENDPOINT": usersApiLambdaEndpoint,
-            "TMT_PRODUCTIZER_LAMBDA_ENDPOINT": tmtProductizerLambdaEndpoint,
-            "JOBS_IN_FINLAND_PRODUCTIZER_LAMBDA_ENDPOINT": jobsInFinlandProductizerLambdaEndpoint,
+            "AUTHENTICATION_GW_ENDPOINT_ORIGIN": authenticationGWLambdaEndpoint,
+            "USERS_API_ENDPOINT_ORIGIN": usersApiLambdaEndpoint,
+            "TMT_PRODUCTIZER_ENDPOINT_ORIGIN": tmtProductizerLambdaEndpoint,
+            "JOBS_IN_FINLAND_PRODUCTIZER_ENDPOINT_ORIGIN": jobsInFinlandProductizerLambdaEndpoint,
         }
     ),
 )

--- a/src/lib/api_app/src/api/requests.rs
+++ b/src/lib/api_app/src/api/requests.rs
@@ -5,6 +5,7 @@ use serde::{ Serialize, Deserialize };
 use std::fmt::Debug;
 use futures::future;
 use stopwatch::{ Stopwatch };
+use std::time::Duration;
 
 use super::{
     responses::{ APIRoutingError, APIRoutingResponse, resolve_external_service_bad_response },
@@ -192,6 +193,7 @@ async fn engage_request<I: Debug + Serialize>(
     let stopwatch = Stopwatch::start_new();
     let response = client
         .request(request_method, endpoint_url)
+        .timeout(Duration::from_secs(29))
         .json(&request_input)
         .headers(request_headers)
         .send().await?;

--- a/src/lib/api_app/src/api/routes/application.rs
+++ b/src/lib/api_app/src/api/routes/application.rs
@@ -75,12 +75,12 @@ pub async fn wake_up_external_services(
     _request: ParsedRequest
 ) -> Result<APIRoutingResponse, APIRoutingError> {
     let endpoints = vec![
-        format!("{}/health", env::var("AUTHENTICATION_GW_LAMBDA_ENDPOINT").unwrap_or_default()),
-        format!("{}", env::var("USERS_API_LAMBDA_ENDPOINT").unwrap_or_default()),
-        format!("{}/wake-up", env::var("TMT_PRODUCTIZER_LAMBDA_ENDPOINT").unwrap_or_default()),
+        format!("{}/health", env::var("AUTHENTICATION_GW_ENDPOINT_ORIGIN").unwrap_or_default()),
+        format!("{}", env::var("USERS_API_ENDPOINT_ORIGIN").unwrap_or_default()),
+        format!("{}/wake-up", env::var("TMT_PRODUCTIZER_ENDPOINT_ORIGIN").unwrap_or_default()),
         format!(
             "{}/wake-up",
-            env::var("JOBS_IN_FINLAND_PRODUCTIZER_LAMBDA_ENDPOINT").unwrap_or_default()
+            env::var("JOBS_IN_FINLAND_PRODUCTIZER_ENDPOINT_ORIGIN").unwrap_or_default()
         )
     ];
     let total_endpoints = endpoints.len();

--- a/src/lib/api_app/src/api/utils.rs
+++ b/src/lib/api_app/src/api/utils.rs
@@ -54,7 +54,7 @@ pub fn get_cors_response_headers() -> HeaderMap {
     headers.insert(
         HeaderName::from_static("access-control-allow-headers"),
         HeaderValue::from_static(
-            "content-type, authorization, x-authorization-provider, x-authorization-context"
+            "content-type, authorization, x-authorization-provider, x-authorization-context, x-consent-token"
         )
     );
 


### PR DESCRIPTION
- allow consent headers passthrough
- fix docker compose networking for linuxes
- fix external api requester inifite wait by adding a forced timeout
- change default local development dependency service endpoints to local addresses